### PR TITLE
fix: Do not fail postinst/prerm on load/unload

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -20,4 +20,4 @@ dkms build ${NAME}/${DVERSION} && dkms install ${NAME}/${DVERSION} || true
 
 udevadm trigger
 
-modprobe xdma-chr
+modprobe xdma-chr || true

--- a/debian/prerm
+++ b/debian/prerm
@@ -12,4 +12,4 @@ echo "Removing ${NAME} driver (${PACKAGE_NAME} ${DVERSION})"
 
 dkms remove ${NAME}/${DVERSION} --all || true
 
-rmmod xdma-chr
+rmmod xdma-chr || true


### PR DESCRIPTION
If we update from the old xdma driver name to the new one, the modprobe xdma-chr will fail since the old module is still loaded (maybe because it could not be unloaded by the prerm of the old package because the server is still running).

Just print the error, but do not fail the postinst/prerm scripts